### PR TITLE
refactor: use 'admonitions' instead of 'notice' to namespace CSS classes

### DIFF
--- a/assets/css/admonitions/style.scss
+++ b/assets/css/admonitions/style.scss
@@ -1,5 +1,5 @@
-// Base colors for notice types
-$notice-colors: (
+// Base colors for admonition types
+$admonition-colors: (
   abstract:   #209fb5,
   caution:    #e64553,
   code:       #7287fd,
@@ -35,15 +35,15 @@ $dark-code-text: #cdd6f4;
 $light-blockquote-border: #e0e0e0;
 $dark-blockquote-border: #45475a;
 
-// Base notice styles
-.notice {
+// Base admonition styles
+.admonition {
   margin: 1rem 0;
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
   transition: all 0.3s ease;
 }
 
-.notice-header {
+.admonition-header {
   padding: 0.5rem 1rem;
   display: flex;
   align-items: center;
@@ -60,7 +60,7 @@ $dark-blockquote-border: #45475a;
   }
 }
 
-.notice-content {
+.admonition-content {
   padding: 1rem;
   background-color: $light-bg;
   border-radius: 0 0 4px 4px;
@@ -96,7 +96,7 @@ $dark-blockquote-border: #45475a;
 
 // Dark mode styles
 @media (prefers-color-scheme: dark) {
-  .notice-content {
+  .admonition-content {
     background-color: $dark-bg;
     color: $dark-text;
 
@@ -113,7 +113,7 @@ $dark-blockquote-border: #45475a;
 }
 
 body.dark {
-  .notice-content {
+  .admonition-content {
     background-color: $dark-bg;
     color: $dark-text;
 
@@ -129,13 +129,13 @@ body.dark {
   }
 }
 
-// Generate notice types
-@each $type, $color in $notice-colors {
-  .notice.#{$type} {
+// Generate admonition types
+@each $type, $color in $admonition-colors {
+  .admonition.#{$type} {
     background: transparent;
     border-left: 4px solid $color;
     
-    .notice-header {
+    .admonition-header {
       background: rgba($color, 0.1);
       color: $color;
     }

--- a/layouts/_default/_markup/render-blockquote-alert.html
+++ b/layouts/_default/_markup/render-blockquote-alert.html
@@ -1,11 +1,11 @@
 {{- /* layouts/_default/_markup/render-blockquote-alert.html */}}
 
 {{- /* Render link element once per page. */}}
-{{- if not (.Page.Store.Get "notice-style-loaded-flag") }}
+{{- if not (.Page.Store.Get "admonition-style-loaded-flag") }}
   {{- with resources.Get "css/admonitions/style.scss" | toCSS | minify | fingerprint }}
     <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}">
   {{- end }}
-  {{- .Page.Store.Set "notice-style-loaded-flag" true }}
+  {{- .Page.Store.Set "admonition-style-loaded-flag" true }}
 {{- end }}
 
 {{- /* Map alert type to icon in layouts/partials/admonitions/icons. */}}
@@ -37,14 +37,14 @@
 {{- $type := cond (index $icons .AlertType) .AlertType "note" }}
 {{- $partial := printf "admonitions/icons/%s" (index $icons $type) }}
 {{- if templates.Exists (printf "partials/%s" $partial) }}
-  <div class="notice {{ $type }}">
-    <div class="notice-header">
+  <div class="admonition {{ $type }}">
+    <div class="admonition-header">
       {{- partialCached $partial . }}
       {{- or .AlertTitle (T (printf "admonitions.%s" .AlertType)) (title .AlertType) }}
     </div>
     {{- /* See https://github.com/gohugoio/hugo/issues/12913. */}}
     {{- if ne .Text "<p>" }}
-      <div class="notice-content">
+      <div class="admonition-content">
         {{ .Text }}
       </div>
     {{- end }}


### PR DESCRIPTION
Fixes #8