### PR TITLE
refactor: remove workaround for upstream issue

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,3 @@
+[module.hugoVersion]
+extended = true
+min = '0.140.0'

--- a/layouts/_default/_markup/render-blockquote-alert.html
+++ b/layouts/_default/_markup/render-blockquote-alert.html
@@ -52,13 +52,12 @@
 {{- if templates.Exists (printf "partials/%s" $partial) }}
   <div class="admonition {{ $type }}">
     <div class="admonition-header">
-      {{- partialCached $partial . }}
-      {{- or .AlertTitle (T (printf "admonitions.%s" .AlertType)) (title .AlertType) }}
+      {{ partialCached $partial . }}
+      <span>{{ or .AlertTitle (T (printf "admonitions.%s" .AlertType)) (title .AlertType) }}</span>
     </div>
-    {{- /* See https://github.com/gohugoio/hugo/issues/12913. */}}
-    {{- if ne .Text "<p>" }}
+    {{- with .Text }}
       <div class="admonition-content">
-        {{ .Text }}
+        {{ . }}
       </div>
     {{- end }}
   </div>

--- a/theme.yaml
+++ b/theme.yaml
@@ -5,13 +5,14 @@ license: MIT
 licenselink: https://github.com/kkkzoz/hugo-admonitions/blob/master/LICENSE
 description: Hugo theme component to display simple and clean callouts.
 homepage: https://github.com/kkkzoz/hugo-admonitions
-min_version: 0.134.1
 
 tags:
-  - component
-  - callout
-  - notice
   - admonition
+  - alert
+  - callout
+  - component
+  - notice
+
 features:
   - nicely display notices
   - easy to use


### PR DESCRIPTION
Do not merge this until the release of Hugo v0.140.0.

This also fixes a problem where flex styling eats white space when the alert title contains markdown. For example:

```
> [!CAUTION] Be _careful_ here
```

This is currently rendered to:

![image](https://github.com/user-attachments/assets/2454e71e-bae6-4708-8134-eee0f8e0bb54)

With this PR the rendering is correct:

![image](https://github.com/user-attachments/assets/c9710d94-d92e-405c-be30-5cd1fb6f41dd)
