### PR TITLE
chore: enforce a minimum required Hugo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hugo-admonitions
+# Hugo-admonitions
 
 A lightweight Hugo module that adds beautiful and customizable admonition blocks to your content.
 
@@ -57,6 +57,9 @@ Inspiration from [mdbook-admonish](https://tommilligan.github.io/mdbook-admonish
 </div>
 
 ## Installation
+
+> [!IMPORTANT]
+> This modules requires Hugo `v0.140.0` or later.
 
 ### Hugo Module
 

--- a/layouts/_default/_markup/render-blockquote-alert.html
+++ b/layouts/_default/_markup/render-blockquote-alert.html
@@ -1,5 +1,11 @@
 {{- /* layouts/_default/_markup/render-blockquote-alert.html */}}
 
+{{- /* Enforce a minimum required Hugo version. */}}
+{{- $minHugoVersion := "0.140.0" }}
+{{- if lt hugo.Version $minHugoVersion }}
+  {{- errorf "Hugo-admonitions requires Hugo v%s or later. Please upgrade Hugo to v%s or higher." $minHugoVersion $minHugoVersion }}
+{{- end -}}
+
 {{- /* Transpile Sass to CSS and render the link element once per page. */}}
 {{- if not (.Page.Store.Get "admonition-style-loaded-flag") }}
   {{- with resources.Get "sass/vendors/_admonitions.scss" }}


### PR DESCRIPTION
### PR Description:

I came across https://github.com/KKKZOZ/hugo-admonitions/pull/15 & realized that Hugo `v0.140.0` is required for this module to work correctly.
This PR enforces a minimum required Hugo version for the project. Specifically, it introduces a check to ensure that Hugo `v0.140.0` or later is being used. If an earlier version is detected, the following error will be triggered:

```
Hugo-admonitions requires Hugo v0.140.0 or later. Please upgrade Hugo to v0.140.0 or higher.
```

### Summary:
- Added a version check using `hugo.Version` to ensure compatibility with Hugo v0.140.0 or later.
- Implemented an error message for users attempting to run the project using Hugo version <  v0.140.0.

--- 

Let me know if you need any changes. Thank you for this project.