### PR TITLE
Updates to handle blockquote before admonition + tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,16 @@ jobs:
 
       - name: Build docs site
         run: hugo --source docs
+
+      - name: Verify HTML output
+        run: |
+          set -euo pipefail
+          test -f docs/public/test-blockquote-before-admonition/index.html
+          test -f docs/public/test-edge-cases/index.html
+
+          grep -R -q 'class="admonition note"' docs/public
+          grep -R -q 'class="admonition warning"' docs/public
+          grep -R -q 'class="admonition tip"' docs/public
+
+          grep -q '<blockquote' docs/public/test-blockquote-before-admonition/index.html
+          grep -q 'class="admonition' docs/public/test-blockquote-before-admonition/index.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,18 +21,5 @@ jobs:
           hugo-version: latest
           extended: true
 
-      - name: Build docs site
-        run: hugo --source docs
-
-      - name: Verify HTML output
-        run: |
-          set -euo pipefail
-          test -f docs/public/test-blockquote-before-admonition/index.html
-          test -f docs/public/test-edge-cases/index.html
-
-          grep -R -q 'class="admonition note"' docs/public
-          grep -R -q 'class="admonition warning"' docs/public
-          grep -R -q 'class="admonition tip"' docs/public
-
-          grep -q '<blockquote' docs/public/test-blockquote-before-admonition/index.html
-          grep -q 'class="admonition' docs/public/test-blockquote-before-admonition/index.html
+      - name: Run tests
+        run: ./scripts/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test Hugo Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: latest
+          extended: true
+
+      - name: Build docs site
+        run: hugo --source docs

--- a/docs/content/test-blockquote-before-admonition.md
+++ b/docs/content/test-blockquote-before-admonition.md
@@ -1,0 +1,40 @@
+---
+title: "Blockquote Before Admonition Test"
+---
+
+## Test Case 1: Blockquote immediately before Admonition (Issue #43)
+
+> Testing
+
+> [!NOTE] This is an awesome admonition
+> The rest of the details here
+
+## Test Case 2: Blockquote with text between (Issue #43)
+
+> Testing
+
+Lorum ipsum
+
+> [!NOTE] This is an awesome admonition
+> The rest of the details here
+
+## Test Case 3: Multiple blockquotes before Admonition
+
+> First blockquote
+
+> Second blockquote
+
+> [!WARNING] This should still render correctly
+> Even with multiple preceding blockquotes
+
+## Test Case 4: Blockquote with blank line before Admonition
+
+> Testing
+
+> [!TIP] This should work fine
+> With a blank line separation
+
+## Test Case 5: Admonition without preceding blockquote (baseline)
+
+> [!NOTE] This is a normal admonition
+> It should render correctly

--- a/docs/content/test-edge-cases.md
+++ b/docs/content/test-edge-cases.md
@@ -1,0 +1,49 @@
+---
+title: "Edge Cases Test"
+---
+
+## Test Case 1: Invalid AlertType fallback
+
+> [!INVALIDTYPE] This should fallback to regular blockquote
+> When AlertType is not recognized
+
+## Test Case 2: Empty AlertType
+
+> This should render as regular blockquote
+> When Type is alert but AlertType is empty
+
+## Test Case 3: All valid admonition types
+
+> [!NOTE] Note admonition
+> This is a note
+
+> [!TIP] Tip admonition
+> This is a tip
+
+> [!WARNING] Warning admonition
+> This is a warning
+
+> [!IMPORTANT] Important admonition
+> This is important
+
+> [!CAUTION] Caution admonition
+> This is a caution
+
+> [!DANGER] Danger admonition
+> This is dangerous
+
+## Test Case 4: Foldable admonitions
+
+> [!NOTE]- Foldable closed
+> This is a foldable note that starts closed
+
+> [!TIP]+ Foldable open
+> This is a foldable tip that starts open
+
+## Test Case 5: Admonitions with custom titles
+
+> [!IDEA] Custom Title
+> This admonition has a custom title
+
+> [!SUCCESS] Another Custom Title
+> This success admonition also has a custom title

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Test script for hugo-admonitions
+# Builds the docs site and validates HTML output
+#
+# Usage: ./scripts/test.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DOCS_DIR="$PROJECT_ROOT/docs"
+PUBLIC_DIR="$DOCS_DIR/public"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=========================================="
+echo "  hugo-admonitions Test Suite"
+echo "=========================================="
+echo ""
+
+# Check Hugo is installed
+if ! command -v hugo &> /dev/null; then
+    echo -e "${RED}ERROR: Hugo is not installed${NC}"
+    echo "Install Hugo extended: https://gohugo.io/installation/"
+    exit 1
+fi
+
+echo -e "${YELLOW}Hugo version:${NC}"
+hugo version
+echo ""
+
+# Clean previous build
+echo -e "${YELLOW}Cleaning previous build...${NC}"
+rm -rf "$PUBLIC_DIR"
+
+# Build the docs site
+echo -e "${YELLOW}Building docs site...${NC}"
+hugo --source "$DOCS_DIR"
+echo ""
+
+# Test 1: Verify HTML files exist
+echo -e "${YELLOW}Test 1: Checking test HTML files exist...${NC}"
+if [[ -f "$PUBLIC_DIR/test-blockquote-before-admonition/index.html" ]]; then
+    echo -e "  ${GREEN}✓${NC} test-blockquote-before-admonition/index.html exists"
+else
+    echo -e "  ${RED}✗${NC} test-blockquote-before-admonition/index.html NOT FOUND"
+    exit 1
+fi
+
+if [[ -f "$PUBLIC_DIR/test-edge-cases/index.html" ]]; then
+    echo -e "  ${GREEN}✓${NC} test-edge-cases/index.html exists"
+else
+    echo -e "  ${RED}✗${NC} test-edge-cases/index.html NOT FOUND"
+    exit 1
+fi
+echo ""
+
+# Test 2: Verify admonition classes exist in output
+echo -e "${YELLOW}Test 2: Checking admonition classes in HTML output...${NC}"
+for class in "admonition note" "admonition warning" "admonition tip"; do
+    if grep -R -q "class=\"$class\"" "$PUBLIC_DIR"; then
+        echo -e "  ${GREEN}✓${NC} Found class=\"$class\""
+    else
+        echo -e "  ${RED}✗${NC} Missing class=\"$class\""
+        exit 1
+    fi
+done
+echo ""
+
+# Test 3: Verify blockquote-before-admonition test has both elements
+echo -e "${YELLOW}Test 3: Checking blockquote + admonition coexistence...${NC}"
+BLOCKQUOTE_TEST="$PUBLIC_DIR/test-blockquote-before-admonition/index.html"
+
+if grep -q '<blockquote' "$BLOCKQUOTE_TEST"; then
+    echo -e "  ${GREEN}✓${NC} Found <blockquote> elements"
+else
+    echo -e "  ${RED}✗${NC} Missing <blockquote> elements"
+    exit 1
+fi
+
+if grep -q 'class="admonition' "$BLOCKQUOTE_TEST"; then
+    echo -e "  ${GREEN}✓${NC} Found admonition elements"
+else
+    echo -e "  ${RED}✗${NC} Missing admonition elements"
+    exit 1
+fi
+echo ""
+
+# Summary
+echo "=========================================="
+echo -e "  ${GREEN}All tests passed!${NC}"
+echo "=========================================="


### PR DESCRIPTION
Fixes #43 

## Changes
- Added test cases to `docs/content/` as requested
- Removed code changes (rolled back separately by maintainer)

## Test files added:
- `docs/content/test-blockquote-before-admonition.md` - Tests for Issue #43
- `docs/content/test-edge-cases.md` - Edge case coverage

These tests validate:
- Blockquote immediately before admonition (Issue #43)
- Multiple blockquotes before admonition
- Invalid/empty AlertType fallback behavior
- All valid admonition types
- Foldable admonitions
- Custom titles

---
*Rebased and restructured per maintainer feedback.*